### PR TITLE
More informative KeyDecodeErrors

### DIFF
--- a/crates/storey/src/containers/item.rs
+++ b/crates/storey/src/containers/item.rs
@@ -4,7 +4,7 @@ use crate::encoding::{DecodableWith, EncodableWith, Encoding};
 use crate::storage::StorageBranch;
 use crate::storage::{Storage, StorageMut};
 
-use super::{KeyDecodeError, Storable};
+use super::Storable;
 
 /// A single item in the storage.
 ///
@@ -72,6 +72,7 @@ where
 {
     type AccessorT<S> = ItemAccess<E, T, S>;
     type Key = ();
+    type KeyDecodeError = ItemKeyDecodeError;
     type Value = T;
     type ValueDecodeError = E::DecodeError;
 
@@ -82,11 +83,11 @@ where
         }
     }
 
-    fn decode_key(key: &[u8]) -> Result<(), KeyDecodeError> {
+    fn decode_key(key: &[u8]) -> Result<(), ItemKeyDecodeError> {
         if key.is_empty() {
             Ok(())
         } else {
-            Err(KeyDecodeError)
+            Err(ItemKeyDecodeError)
         }
     }
 
@@ -94,6 +95,10 @@ where
         T::decode(value)
     }
 }
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+#[error("invalid key length, expected empty key")]
+pub struct ItemKeyDecodeError;
 
 /// An accessor for an `Item`.
 ///

--- a/crates/storey/src/containers/map.rs
+++ b/crates/storey/src/containers/map.rs
@@ -263,7 +263,9 @@ pub trait Key {
 }
 
 pub trait OwnedKey: Key {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ()>
+    type Error;
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
     where
         Self: Sized;
 }
@@ -274,12 +276,20 @@ impl Key for String {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+#[error("invalid UTF8")]
+pub struct InvalidUtf8;
+
 impl OwnedKey for String {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ()>
+    type Error = InvalidUtf8;
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {
-        std::str::from_utf8(bytes).map(String::from).map_err(|_| ())
+        std::str::from_utf8(bytes)
+            .map(String::from)
+            .map_err(|_| InvalidUtf8)
     }
 }
 


### PR DESCRIPTION
Part of #18 

- [x] add support for custom key decode errors at container interface level
- [x] more informative `containers::map::OwnedKey::from_bytes` errors