### PR TITLE
Use single-byte keys for top-level containers

### DIFF
--- a/packages/cw-storey/tests/smoke_test.rs
+++ b/packages/cw-storey/tests/smoke_test.rs
@@ -6,12 +6,12 @@ use cosmwasm_std::Storage as _;
 fn smoke_test() {
     let mut storage = CwStorage(cosmwasm_std::testing::MockStorage::new());
 
-    let item1 = Item::<u64>::new(&[0]);
+    let item1 = Item::<u64>::new(0);
 
     item1.access(&mut storage).set(&42).unwrap();
     assert_eq!(item1.access(&storage).get().unwrap(), Some(42));
 
-    let item2 = Item::<u64>::new(&[1]);
+    let item2 = Item::<u64>::new(1);
     assert_eq!(item2.access(&storage).get().unwrap(), None);
 
     assert_eq!(storage.0.get(&[0]), Some(vec![42]));

--- a/packages/storey/src/containers/column.rs
+++ b/packages/storey/src/containers/column.rs
@@ -24,7 +24,7 @@ const META_LEN: &[u8] = &[1];
 /// use storey::containers::Column;
 ///
 /// let mut storage = TestStorage::new();
-/// let column = Column::<u64, TestEncoding>::new(&[0]);
+/// let column = Column::<u64, TestEncoding>::new(0);
 /// let mut access = column.access(&mut storage);
 ///
 /// access.push(&1337).unwrap();
@@ -35,7 +35,7 @@ const META_LEN: &[u8] = &[1];
 /// assert_eq!(access.get(2).unwrap(), None);
 /// ```
 pub struct Column<T, E> {
-    prefix: &'static [u8],
+    prefix: u8,
     phantom: PhantomData<(T, E)>,
 }
 
@@ -50,7 +50,7 @@ where
     /// with other keys in the storage.
     ///
     /// The key provided here is used as a prefix for all keys the column itself might generate.
-    pub const fn new(prefix: &'static [u8]) -> Self {
+    pub const fn new(prefix: u8) -> Self {
         Self {
             prefix,
             phantom: PhantomData,
@@ -67,16 +67,16 @@ where
     ///
     /// // immutable accessor
     /// let storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let access = column.access(&storage);
     ///
     /// // mutable accessor
     /// let mut storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let mut access = column.access(&mut storage);
     /// ```
     pub fn access<S>(&self, storage: S) -> ColumnAccess<E, T, StorageBranch<S>> {
-        Self::access_impl(StorageBranch::new(storage, self.prefix.to_vec()))
+        Self::access_impl(StorageBranch::new(storage, vec![self.prefix]))
     }
 }
 
@@ -150,7 +150,7 @@ where
     /// use storey::containers::Column;
     ///
     /// let mut storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let mut access = column.access(&mut storage);
     ///
     /// access.push(&1337).unwrap();
@@ -174,7 +174,7 @@ where
     /// use storey::containers::Column;
     ///
     /// let mut storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let mut access = column.access(&mut storage);
     ///
     /// assert_eq!(access.len().unwrap(), 0);
@@ -207,7 +207,7 @@ where
     /// use storey::containers::Column;
     ///
     /// let mut storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let mut access = column.access(&mut storage);
     ///
     /// assert_eq!(access.is_empty().unwrap(), true);
@@ -250,7 +250,7 @@ where
     /// use storey::containers::Column;
     ///
     /// let mut storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let mut access = column.access(&mut storage);
     ///
     /// access.push(&1337).unwrap();
@@ -290,7 +290,7 @@ where
     /// use storey::containers::Column;
     ///
     /// let mut storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let mut access = column.access(&mut storage);
     ///
     /// access.push(&1337).unwrap();
@@ -322,7 +322,7 @@ where
     /// use storey::containers::Column;
     ///
     /// let mut storage = TestStorage::new();
-    /// let column = Column::<u64, TestEncoding>::new(&[0]);
+    /// let column = Column::<u64, TestEncoding>::new(0);
     /// let mut access = column.access(&mut storage);
     ///
     /// access.push(&1337).unwrap();
@@ -396,7 +396,7 @@ mod tests {
     fn basic() {
         let mut storage = TestStorage::new();
 
-        let column = Column::<u64, TestEncoding>::new(&[0]);
+        let column = Column::<u64, TestEncoding>::new(0);
         let mut access = column.access(&mut storage);
 
         access.push(&1337).unwrap();
@@ -420,7 +420,7 @@ mod tests {
     fn iteration() {
         let mut storage = TestStorage::new();
 
-        let column = Column::<u64, TestEncoding>::new(&[0]);
+        let column = Column::<u64, TestEncoding>::new(0);
         let mut access = column.access(&mut storage);
 
         access.push(&1337).unwrap();

--- a/packages/storey/src/containers/item.rs
+++ b/packages/storey/src/containers/item.rs
@@ -18,13 +18,13 @@ use super::Storable;
 /// use storey::containers::Item;
 ///
 /// let mut storage = TestStorage::new();
-/// let item = Item::<u64, TestEncoding>::new(&[0]);
+/// let item = Item::<u64, TestEncoding>::new(0);
 ///
 /// item.access(&mut storage).set(&42).unwrap();
 /// assert_eq!(item.access(&storage).get().unwrap(), Some(42));
 /// ```
 pub struct Item<T, E> {
-    prefix: &'static [u8],
+    key: u8,
     phantom: PhantomData<(T, E)>,
 }
 
@@ -36,9 +36,9 @@ where
     /// Create a new item with the given key.
     ///
     /// It is the responsibility of the caller to ensure that the key is unique.
-    pub const fn new(prefix: &'static [u8]) -> Self {
+    pub const fn new(key: u8) -> Self {
         Self {
-            prefix,
+            key,
             phantom: PhantomData,
         }
     }
@@ -53,15 +53,15 @@ where
     ///
     /// // immutable accessor
     /// let storage = TestStorage::new();
-    /// let item = Item::<u64, TestEncoding>::new(&[0]);
+    /// let item = Item::<u64, TestEncoding>::new(0);
     /// let access = item.access(&storage);
     ///
     /// // mutable accessor
     /// let mut storage = TestStorage::new();
-    /// let item = Item::<u64, TestEncoding>::new(&[0]);
+    /// let item = Item::<u64, TestEncoding>::new(0);
     /// let mut access = item.access(&mut storage);
     pub fn access<S>(&self, storage: S) -> ItemAccess<E, T, StorageBranch<S>> {
-        Self::access_impl(StorageBranch::new(storage, self.prefix.to_vec()))
+        Self::access_impl(StorageBranch::new(storage, vec![self.key]))
     }
 }
 
@@ -125,7 +125,7 @@ where
     /// use storey::containers::Item;
     ///
     /// let storage = TestStorage::new();
-    /// let item = Item::<u64, TestEncoding>::new(&[0]);
+    /// let item = Item::<u64, TestEncoding>::new(0);
     /// let access = item.access(&storage);
     ///
     /// assert_eq!(access.get().unwrap(), None);
@@ -137,7 +137,7 @@ where
     /// use storey::containers::Item;
     ///
     /// let mut storage = TestStorage::new();
-    /// let item = Item::<u64, TestEncoding>::new(&[0]);
+    /// let item = Item::<u64, TestEncoding>::new(0);
     ///
     /// item.access(&mut storage).set(&42).unwrap();
     /// assert_eq!(item.access(&storage).get().unwrap(), Some(42));
@@ -165,7 +165,7 @@ where
     /// use storey::containers::Item;
     ///
     /// let mut storage = TestStorage::new();
-    /// let item = Item::<u64, TestEncoding>::new(&[0]);
+    /// let item = Item::<u64, TestEncoding>::new(0);
     ///
     /// item.access(&mut storage).set(&42).unwrap();
     /// assert_eq!(item.access(&storage).get().unwrap(), Some(42));
@@ -188,10 +188,10 @@ mod tests {
     fn basic() {
         let mut storage = TestStorage::new();
 
-        let item0 = Item::<u64, TestEncoding>::new(&[0]);
+        let item0 = Item::<u64, TestEncoding>::new(0);
         item0.access(&mut storage).set(&42).unwrap();
 
-        let item1 = Item::<u64, TestEncoding>::new(&[1]);
+        let item1 = Item::<u64, TestEncoding>::new(1);
         let access1 = item1.access(&storage);
 
         assert_eq!(item0.access(&storage).get().unwrap(), Some(42));

--- a/packages/storey/src/containers/map.rs
+++ b/packages/storey/src/containers/map.rs
@@ -21,7 +21,7 @@ use super::Storable;
 /// use storey::containers::{Item, Map};
 ///
 /// let mut storage = TestStorage::new();
-/// let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+/// let map = Map::<String, Item<u64, TestEncoding>>::new(0);
 /// let mut access = map.access(&mut storage);
 ///
 /// access.entry_mut("foo").set(&1337).unwrap();
@@ -35,7 +35,7 @@ use super::Storable;
 /// use storey::containers::{Item, Map};
 ///
 /// let mut storage = TestStorage::new();
-/// let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(&[0]);
+/// let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(0);
 /// let mut access = map.access(&mut storage);
 ///
 /// access.entry_mut("foo").entry_mut("bar").set(&1337).unwrap();
@@ -43,7 +43,7 @@ use super::Storable;
 /// assert_eq!(access.entry("foo").entry("baz").get().unwrap(), None);
 /// ```
 pub struct Map<K: ?Sized, V> {
-    prefix: &'static [u8],
+    prefix: u8,
     phantom: PhantomData<(*const K, V)>,
 }
 
@@ -59,7 +59,7 @@ where
     /// with other keys in the storage.
     ///
     /// The key provided here is used as a prefix for all keys managed by the map.
-    pub const fn new(prefix: &'static [u8]) -> Self {
+    pub const fn new(prefix: u8) -> Self {
         Self {
             prefix,
             phantom: PhantomData,
@@ -76,16 +76,16 @@ where
     ///
     /// // immutable access
     /// let storage = TestStorage::new();
-    /// let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+    /// let map = Map::<String, Item<u64, TestEncoding>>::new(0);
     /// let access = map.access(&storage);
     ///
     /// // mutable access
     /// let mut storage = TestStorage::new();
-    /// let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+    /// let map = Map::<String, Item<u64, TestEncoding>>::new(0);
     /// let mut access = map.access(&mut storage);
     /// ```
     pub fn access<S>(&self, storage: S) -> MapAccess<K, V, StorageBranch<S>> {
-        Self::access_impl(StorageBranch::new(storage, self.prefix.to_vec()))
+        Self::access_impl(StorageBranch::new(storage, vec![self.prefix]))
     }
 }
 
@@ -166,7 +166,7 @@ where
     /// use storey::containers::{Item, Map};
     ///
     /// let storage = TestStorage::new();
-    /// let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+    /// let map = Map::<String, Item<u64, TestEncoding>>::new(0);
     /// let access = map.access(&storage);
     ///
     /// assert_eq!(access.entry("foo").get().unwrap(), None);
@@ -178,7 +178,7 @@ where
     /// use storey::containers::{Item, Map};
     ///
     /// let storage = TestStorage::new();
-    /// let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(&[0]);
+    /// let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(0);
     /// let access = map.access(&storage);
     ///
     /// assert_eq!(access.entry("foo").entry("bar").get().unwrap(), None);
@@ -208,7 +208,7 @@ where
     /// use storey::containers::{Item, Map};
     ///
     /// let mut storage = TestStorage::new();
-    /// let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+    /// let map = Map::<String, Item<u64, TestEncoding>>::new(0);
     /// let mut access = map.access(&mut storage);
     ///
     /// access.entry_mut("foo").set(&1337).unwrap();
@@ -221,7 +221,7 @@ where
     /// use storey::containers::{Item, Map};
     ///
     /// let mut storage = TestStorage::new();
-    /// let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(&[0]);
+    /// let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(0);
     /// let mut access = map.access(&mut storage);
     ///
     /// access.entry_mut("foo").entry_mut("bar").set(&1337).unwrap();
@@ -313,7 +313,7 @@ mod tests {
     fn map() {
         let mut storage = TestStorage::new();
 
-        let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+        let map = Map::<String, Item<u64, TestEncoding>>::new(0);
 
         map.access(&mut storage)
             .entry_mut("foo")
@@ -332,7 +332,7 @@ mod tests {
     fn pairs() {
         let mut storage = TestStorage::new();
 
-        let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+        let map = Map::<String, Item<u64, TestEncoding>>::new(0);
         let mut access = map.access(&mut storage);
 
         access.entry_mut("foo").set(&1337).unwrap();
@@ -355,7 +355,7 @@ mod tests {
     fn keys() {
         let mut storage = TestStorage::new();
 
-        let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+        let map = Map::<String, Item<u64, TestEncoding>>::new(0);
         let mut access = map.access(&mut storage);
 
         access.entry_mut("foo").set(&1337).unwrap();
@@ -372,7 +372,7 @@ mod tests {
     fn values() {
         let mut storage = TestStorage::new();
 
-        let map = Map::<String, Item<u64, TestEncoding>>::new(&[0]);
+        let map = Map::<String, Item<u64, TestEncoding>>::new(0);
         let mut access = map.access(&mut storage);
 
         access.entry_mut("foo").set(&1337).unwrap();

--- a/packages/storey/tests/composition.rs
+++ b/packages/storey/tests/composition.rs
@@ -8,7 +8,7 @@ use storey_storage::Storage as _;
 fn map_of_map() {
     let mut storage = TestStorage::new();
 
-    let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(&[0]);
+    let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(0);
 
     map.access(&mut storage)
         .entry_mut("foo")
@@ -42,7 +42,7 @@ fn map_of_map() {
 fn map_of_column() {
     let mut storage = TestStorage::new();
 
-    let map = Map::<String, Column<u64, TestEncoding>>::new(&[0]);
+    let map = Map::<String, Column<u64, TestEncoding>>::new(0);
     let mut access = map.access(&mut storage);
 
     access.entry_mut("foo").push(&1337).unwrap();

--- a/packages/storey/tests/iteration.rs
+++ b/packages/storey/tests/iteration.rs
@@ -7,7 +7,7 @@ use mocks::encoding::TestEncoding;
 fn map_of_map_iteration() {
     let mut storage = TestStorage::new();
 
-    let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(&[0]);
+    let map = Map::<String, Map<String, Item<u64, TestEncoding>>>::new(0);
     let mut access = map.access(&mut storage);
 
     // populate with data


### PR DESCRIPTION
Closes #31 