### PR TITLE
cw-storey: Switch to the MsgPack encoding provided by `cosmwasm-std`

### DIFF
--- a/packages/cw-storey/Cargo.toml
+++ b/packages/cw-storey/Cargo.toml
@@ -11,8 +11,11 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-rmp-serde = "1"
 cosmwasm-std = "2"
 serde = "1"
+
+# TODO: temporary, remove after this is released:
+# https://github.com/CosmWasm/cosmwasm/pull/2118
+cosmwasm-std-new = { git = "https://github.com/CosmWasm/cosmwasm.git", rev = "553bdd6fc5cc9c74bebcba99a89c0c4334b8824d", package = "cosmwasm-std" }
 
 storey = { workspace = true }

--- a/packages/cw-storey/src/encoding.rs
+++ b/packages/cw-storey/src/encoding.rs
@@ -1,6 +1,6 @@
 use storey::encoding::{Cover, DecodableWithImpl, EncodableWithImpl, Encoding};
 
-/// A simple encoding that uses [*MessagePack*] to encode and decode data.
+/// An encoding that delegates to the [*MessagePack*] encoding provided by the [`cosmwasm_std`] crate.
 ///
 /// This type implements the [`Encoding`] trait (see [`storey::encoding`]), which means it can
 /// be used with some of [`storey`]'s containers to encode and decode values.
@@ -9,19 +9,20 @@ use storey::encoding::{Cover, DecodableWithImpl, EncodableWithImpl, Encoding};
 /// need it if you're trying to use third-party containers this crate does not provide.
 ///
 /// [*MessagePack*]: https://msgpack.org/
+/// [`cosmwasm_std`]: https://docs.rs/cosmwasm-std
 pub struct CwEncoding;
 
 impl Encoding for CwEncoding {
-    type DecodeError = ();
-    type EncodeError = ();
+    type DecodeError = cosmwasm_std_new::StdError;
+    type EncodeError = cosmwasm_std_new::StdError;
 }
 
 impl<T> EncodableWithImpl<CwEncoding> for Cover<&T>
 where
     T: serde::Serialize,
 {
-    fn encode_impl(self) -> Result<Vec<u8>, ()> {
-        rmp_serde::to_vec(self.0).map_err(|_| ())
+    fn encode_impl(self) -> Result<Vec<u8>, cosmwasm_std_new::StdError> {
+        cosmwasm_std_new::to_msgpack_vec(self.0)
     }
 }
 
@@ -29,7 +30,7 @@ impl<T> DecodableWithImpl<CwEncoding> for Cover<T>
 where
     T: serde::de::DeserializeOwned,
 {
-    fn decode_impl(data: &[u8]) -> Result<Self, ()> {
-        rmp_serde::from_slice(data).map(Cover).map_err(|_| ())
+    fn decode_impl(data: &[u8]) -> Result<Self, cosmwasm_std_new::StdError> {
+        cosmwasm_std_new::from_msgpack(data).map(Cover)
     }
 }


### PR DESCRIPTION
This is breaking for two reasons:
- We're switching to the **self-describing** version of `rmp-serde`, where structs are maps and not vectors.
- We now provide an actual error type (`StdError`).