### PR TITLE
[prototype] Map key redesign

### DIFF
--- a/packages/cw-storey/src/lib.rs
+++ b/packages/cw-storey/src/lib.rs
@@ -3,9 +3,9 @@
 //! This crate provides
 //! - a [*CosmWasm*] storage backend for use with [`storey`] collections,
 //! - a [*MessagePack*] encoding integration to be used for serializing and deserializing
-//! values, and
+//!   values, and
 //! - a set of container re-exports that remove the need to manually specify the
-//! encoding, instead relying on the default [*MessagePack*] encoding.
+//!   encoding, instead relying on the default [*MessagePack*] encoding.
 //!
 //! [*CosmWasm*]: https://github.com/CosmWasm/cosmwasm
 //! [*MessagePack*]: https://msgpack.org/

--- a/packages/storey/src/containers/column.rs
+++ b/packages/storey/src/containers/column.rs
@@ -7,7 +7,7 @@ use crate::encoding::{DecodableWith, EncodableWith};
 use crate::storage::{IterableStorage, StorageBranch};
 use crate::storage::{Storage, StorageMut};
 
-use super::{BoundFor, BoundedIterableAccessor, IterableAccessor, Storable};
+use super::{BoundFor, BoundedIterableAccessor, IterableAccessor, NonTerminal, Storable};
 
 const META_LAST_IX: &[u8] = &[0];
 const META_LEN: &[u8] = &[1];
@@ -85,6 +85,7 @@ where
     E: Encoding,
     T: EncodableWith<E> + DecodableWith<E>,
 {
+    type Kind = NonTerminal;
     type Accessor<S> = ColumnAccess<E, T, S>;
     type Key = u32;
     type KeyDecodeError = ColumnKeyDecodeError;

--- a/packages/storey/src/containers/item.rs
+++ b/packages/storey/src/containers/item.rs
@@ -4,7 +4,7 @@ use crate::encoding::{DecodableWith, EncodableWith, Encoding};
 use crate::storage::StorageBranch;
 use crate::storage::{Storage, StorageMut};
 
-use super::Storable;
+use super::{Storable, Terminal};
 
 /// A single item in the storage.
 ///
@@ -70,6 +70,7 @@ where
     E: Encoding,
     T: EncodableWith<E> + DecodableWith<E>,
 {
+    type Kind = Terminal;
     type Accessor<S> = ItemAccess<E, T, S>;
     type Key = ();
     type KeyDecodeError = ItemKeyDecodeError;

--- a/packages/storey/src/containers/map/key.rs
+++ b/packages/storey/src/containers/map/key.rs
@@ -1,12 +1,18 @@
+/// A key that can be used with a [`Map`](crate::Map).
 pub trait Key {
+    /// The kind of key, meaning either fixed size or dynamic size.
     type Kind: KeyKind;
 
+    /// Encode the key into a byte vector.
     fn encode(&self) -> Vec<u8>;
 }
 
+/// An owned key that can be used with a [`Map`](crate::Map).
 pub trait OwnedKey: Key {
+    /// The error type that can occur when decoding the key.
     type Error;
 
+    /// Decode the key from a byte slice.
     fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
     where
         Self: Sized;
@@ -28,6 +34,7 @@ impl Key for str {
     }
 }
 
+/// An error type representing a failure to decode a UTF-8 string.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
 #[error("invalid UTF8")]
 pub struct InvalidUtf8;
@@ -45,14 +52,25 @@ impl OwnedKey for String {
     }
 }
 
+/// A trait specifying the kind of key.
+///
+/// There are two kinds of keys: fixed-size keys and dynamic keys, which are
+/// represented by the [`FixedSizeKey`] and [`DynamicKey`] types, respectively.
+///
+/// This trait is [sealed](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits)
+/// and cannot be implemented outside of this crate.
 pub trait KeyKind {}
 
+/// A marker type representing a fixed-size key.
 pub struct FixedSizeKey<const L: usize>;
+
+/// A marker type representing a dynamic-size key.
 pub struct DynamicKey;
 
 impl<const L: usize> KeyKind for FixedSizeKey<L> {}
 impl KeyKind for DynamicKey {}
 
+/// An error type for decoding numeric keys.
 pub enum NumericKeyDecodeError {
     InvalidLength,
 }

--- a/packages/storey/src/containers/map/key.rs
+++ b/packages/storey/src/containers/map/key.rs
@@ -59,7 +59,7 @@ impl OwnedKey for String {
 ///
 /// This trait is [sealed](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits)
 /// and cannot be implemented outside of this crate.
-pub trait KeyKind {}
+pub trait KeyKind: sealed::KeyKindSeal {}
 
 /// A marker type representing a fixed-size key.
 pub struct FixedSizeKey<const L: usize>;
@@ -69,6 +69,13 @@ pub struct DynamicKey;
 
 impl<const L: usize> KeyKind for FixedSizeKey<L> {}
 impl KeyKind for DynamicKey {}
+
+mod sealed {
+    pub trait KeyKindSeal {}
+
+    impl<const L: usize> KeyKindSeal for super::FixedSizeKey<L> {}
+    impl KeyKindSeal for super::DynamicKey {}
+}
 
 /// An error type for decoding numeric keys.
 pub enum NumericKeyDecodeError {

--- a/packages/storey/src/containers/map/key.rs
+++ b/packages/storey/src/containers/map/key.rs
@@ -1,0 +1,99 @@
+pub trait Key {
+    type Kind: KeyKind;
+
+    fn encode(&self) -> Vec<u8>;
+}
+
+pub trait OwnedKey: Key {
+    type Error;
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+impl Key for String {
+    type Kind = DynamicKey;
+
+    fn encode(&self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+}
+
+impl Key for str {
+    type Kind = DynamicKey;
+
+    fn encode(&self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+#[error("invalid UTF8")]
+pub struct InvalidUtf8;
+
+impl OwnedKey for String {
+    type Error = InvalidUtf8;
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        std::str::from_utf8(bytes)
+            .map(String::from)
+            .map_err(|_| InvalidUtf8)
+    }
+}
+
+pub trait KeyKind {}
+
+pub struct FixedSizeKey<const L: usize>;
+pub struct DynamicKey;
+
+impl<const L: usize> KeyKind for FixedSizeKey<L> {}
+impl KeyKind for DynamicKey {}
+
+pub enum NumericKeyDecodeError {
+    InvalidLength,
+}
+
+macro_rules! impl_key_for_numeric {
+    ($($t:ty),*) => {
+        $(
+            impl Key for $t {
+                type Kind = FixedSizeKey<{(Self::BITS / 8) as usize}>;
+
+                fn encode(&self) -> Vec<u8> {
+                    self.to_be_bytes().to_vec()
+                }
+            }
+
+            impl OwnedKey for $t {
+                type Error = NumericKeyDecodeError;
+
+                fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
+                where
+                    Self: Sized,
+                {
+                    if bytes.len() != std::mem::size_of::<Self>() {
+                        return Err(NumericKeyDecodeError::InvalidLength);
+                    }
+
+                    let mut buf = [0; std::mem::size_of::<Self>()];
+                    buf.copy_from_slice(bytes);
+                    Ok(Self::from_be_bytes(buf))
+                }
+            }
+        )*
+    };
+}
+
+impl_key_for_numeric!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+
+impl<const N: usize> Key for [u8; N] {
+    type Kind = FixedSizeKey<N>;
+
+    fn encode(&self) -> Vec<u8> {
+        self.to_vec()
+    }
+}

--- a/packages/storey/src/containers/map/key_encoding.rs
+++ b/packages/storey/src/containers/map/key_encoding.rs
@@ -1,0 +1,45 @@
+use crate::containers::{NonTerminal, Terminal};
+
+use super::key::{DynamicKey, FixedSizeKey};
+
+/// A trait that specifies the encoding strategy for a key.
+///
+/// This trait is implemented on tuples of the form `(K, C)` where `K` is the key type (dynamic/fixed)
+/// and `C` is the container type (terminal/nonterminal). Once we know these two properties, we can
+/// determine the encoding strategy for the key.
+///
+/// Scenarios:
+/// - If the key is dynamic and the container is nonterminal, then the key needs to be
+///   length prefixed - otherwise, we would not know where the key ends and the key for the inner
+///   container starts.
+/// - If the key is dynamic and the container is terminal, then the key is the rest of the string.
+/// - If the key is fixed size, then we statically provide the number of bytes to read/write.
+pub trait KeyEncodingT {
+    const BEHAVIOR: KeyEncoding;
+}
+
+impl KeyEncodingT for (DynamicKey, NonTerminal) {
+    const BEHAVIOR: KeyEncoding = KeyEncoding::LenPrefix;
+}
+
+impl<const L: usize> KeyEncodingT for (FixedSizeKey<L>, Terminal) {
+    const BEHAVIOR: KeyEncoding = KeyEncoding::UseRest;
+}
+
+impl KeyEncodingT for (DynamicKey, Terminal) {
+    const BEHAVIOR: KeyEncoding = KeyEncoding::UseRest;
+}
+
+impl<const L: usize> KeyEncodingT for (FixedSizeKey<L>, NonTerminal) {
+    const BEHAVIOR: KeyEncoding = KeyEncoding::UseN(L);
+}
+
+/// The encoding strategy for a given key.
+pub enum KeyEncoding {
+    /// The key needs to be length prefixed.
+    LenPrefix,
+    /// The key doesn't need to be length prefixed. The rest of the string is the key.
+    UseRest,
+    /// The key is of fixed size.
+    UseN(usize),
+}

--- a/packages/storey/src/containers/map/mod.rs
+++ b/packages/storey/src/containers/map/mod.rs
@@ -223,7 +223,7 @@ where
     pub fn entry<Q>(&self, key: &Q) -> V::Accessor<StorageBranch<&S>>
     where
         K: Borrow<Q>,
-        Q: Key + ?Sized,
+        Q: Key<Kind = K::Kind> + ?Sized,
     {
         let behavior = <(K::Kind, V::Kind)>::BEHAVIOR;
 
@@ -267,7 +267,7 @@ where
     pub fn entry_mut<Q>(&mut self, key: &Q) -> V::Accessor<StorageBranch<&mut S>>
     where
         K: Borrow<Q>,
-        Q: Key + ?Sized,
+        Q: Key<Kind = K::Kind> + ?Sized,
     {
         let behavior = <(K::Kind, V::Kind)>::BEHAVIOR;
 

--- a/packages/storey/src/containers/map/mod.rs
+++ b/packages/storey/src/containers/map/mod.rs
@@ -1,4 +1,4 @@
-mod key;
+pub mod key;
 mod key_encoding;
 
 pub use key::{Key, OwnedKey};

--- a/packages/storey/src/containers/map/mod.rs
+++ b/packages/storey/src/containers/map/mod.rs
@@ -1,10 +1,21 @@
+mod key;
+
+pub use key::{Key, OwnedKey};
+
 use std::{borrow::Borrow, marker::PhantomData};
 
 use crate::storage::IterableStorage;
 use crate::storage::StorageBranch;
 
+use self::key::DynamicKey;
+use self::key::FixedSizeKey;
+
+use super::BoundFor;
+use super::BoundedIterableAccessor;
 use super::IterableAccessor;
+use super::NonTerminal;
 use super::Storable;
+use super::Terminal;
 
 /// A map that stores values of type `V` under keys of type `K`.
 ///
@@ -52,6 +63,7 @@ where
     K: OwnedKey,
     V: Storable,
     <V as Storable>::KeyDecodeError: std::fmt::Display,
+    (K::Kind, V::Kind): KeyDecodeBehaviorT,
 {
     /// Creates a new map with the given prefix.
     ///
@@ -94,7 +106,9 @@ where
     K: OwnedKey,
     V: Storable,
     <V as Storable>::KeyDecodeError: std::fmt::Display,
+    (K::Kind, V::Kind): KeyDecodeBehaviorT,
 {
+    type Kind = NonTerminal;
     type Accessor<S> = MapAccess<K, V, S>;
     type Key = (K, V::Key);
     type KeyDecodeError = MapKeyDecodeError<V::KeyDecodeError>;
@@ -109,17 +123,36 @@ where
     }
 
     fn decode_key(key: &[u8]) -> Result<Self::Key, MapKeyDecodeError<V::KeyDecodeError>> {
-        let len = *key.first().ok_or(MapKeyDecodeError::EmptyKey)? as usize;
+        let behavior = <(K::Kind, V::Kind)>::BEHAVIOR;
 
-        if key.len() < len + 1 {
-            return Err(MapKeyDecodeError::KeyTooShort(len));
+        match behavior {
+            KeyDecodeBehavior::FollowLenPrefix => {
+                let len = *key.first().ok_or(MapKeyDecodeError::EmptyKey)? as usize;
+
+                if key.len() < len + 1 {
+                    return Err(MapKeyDecodeError::KeyTooShort(len));
+                }
+
+                let map_key =
+                    K::from_bytes(&key[1..len + 1]).map_err(|_| MapKeyDecodeError::InvalidUtf8)?;
+                let rest = V::decode_key(&key[len + 1..]).map_err(MapKeyDecodeError::Inner)?;
+
+                Ok((map_key, rest))
+            }
+            KeyDecodeBehavior::UseRest => {
+                let map_key = K::from_bytes(key).map_err(|_| MapKeyDecodeError::InvalidUtf8)?;
+                let rest = V::decode_key(&[]).map_err(MapKeyDecodeError::Inner)?;
+
+                Ok((map_key, rest))
+            }
+            KeyDecodeBehavior::UseN(n) => {
+                let map_key =
+                    K::from_bytes(&key[..n]).map_err(|_| MapKeyDecodeError::InvalidUtf8)?;
+                let rest = V::decode_key(&key[n..]).map_err(MapKeyDecodeError::Inner)?;
+
+                Ok((map_key, rest))
+            }
         }
-
-        let map_key =
-            K::from_bytes(&key[1..len + 1]).map_err(|_| MapKeyDecodeError::InvalidUtf8)?;
-        let rest = V::decode_key(&key[len + 1..]).map_err(MapKeyDecodeError::Inner)?;
-
-        Ok((map_key, rest))
     }
 
     fn decode_value(value: &[u8]) -> Result<Self::Value, Self::ValueDecodeError> {
@@ -155,6 +188,7 @@ impl<K, V, S> MapAccess<K, V, S>
 where
     K: Key,
     V: Storable,
+    (K::Kind, V::Kind): KeyDecodeBehaviorT,
 {
     /// Returns an immutable accessor for the inner container of this map.
     ///
@@ -188,7 +222,12 @@ where
         K: Borrow<Q>,
         Q: Key + ?Sized,
     {
-        let key = length_prefixed_key(key);
+        let behavior = <(K::Kind, V::Kind)>::BEHAVIOR;
+
+        let key = match behavior {
+            KeyDecodeBehavior::FollowLenPrefix => len_prefix(key.encode()),
+            _ => key.encode(),
+        };
 
         V::access_impl(StorageBranch::new(&self.storage, key))
     }
@@ -227,21 +266,23 @@ where
         K: Borrow<Q>,
         Q: Key + ?Sized,
     {
-        let key = length_prefixed_key(key);
+        let behavior = <(K::Kind, V::Kind)>::BEHAVIOR;
+
+        let key = match behavior {
+            KeyDecodeBehavior::FollowLenPrefix => len_prefix(key.encode()),
+            _ => key.encode(),
+        };
 
         V::access_impl(StorageBranch::new(&mut self.storage, key))
     }
 }
 
-fn length_prefixed_key<K: Key + ?Sized>(key: &K) -> Vec<u8> {
-    let len = key.bytes().len();
-    let bytes = key.bytes();
-    let mut key = Vec::with_capacity(len + 1);
-
-    key.push(len as u8);
-    key.extend_from_slice(bytes);
-
-    key
+fn len_prefix<T: AsRef<[u8]>>(bytes: T) -> Vec<u8> {
+    let len = bytes.as_ref().len();
+    let mut result = Vec::with_capacity(len + 1);
+    result.extend_from_slice(&(len as u8).to_be_bytes());
+    result.extend_from_slice(bytes.as_ref());
+    result
 }
 
 impl<K, V, S> IterableAccessor for MapAccess<K, V, S>
@@ -250,6 +291,7 @@ where
     V: Storable,
     <V as Storable>::KeyDecodeError: std::fmt::Display,
     S: IterableStorage,
+    (K::Kind, V::Kind): KeyDecodeBehaviorT,
 {
     type Storable = Map<K, V>;
     type Storage = S;
@@ -259,44 +301,69 @@ where
     }
 }
 
-pub trait Key {
-    fn bytes(&self) -> &[u8];
+// The following dance is necessary to make bounded iteration unavailable for maps
+// that have both dynamic keys and "non-terminal" values (i.e. maps of maps, maps of columns, etc).
+//
+// This is because in cases where the key is dynamically size **and** there's another key
+// after it, we have to length-prefix the key. This makes bounded iteration behave differently
+// than in other cases (and rather unintuitively).
+
+impl<K, V, S> BoundedIterableAccessor for MapAccess<K, V, S>
+where
+    K: OwnedKey,
+    V: Storable,
+    <V as Storable>::KeyDecodeError: std::fmt::Display,
+    S: IterableStorage,
+    (K::Kind, V::Kind): BoundedIterationAllowed + KeyDecodeBehaviorT,
+{
 }
 
-pub trait OwnedKey: Key {
-    type Error;
+trait BoundedIterationAllowed {}
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
-    where
-        Self: Sized;
+impl<const L: usize> BoundedIterationAllowed for (FixedSizeKey<L>, Terminal) {}
+impl<const L: usize> BoundedIterationAllowed for (FixedSizeKey<L>, NonTerminal) {}
+impl BoundedIterationAllowed for (DynamicKey, Terminal) {}
+
+trait KeyDecodeBehaviorT {
+    const BEHAVIOR: KeyDecodeBehavior;
 }
 
-impl Key for String {
-    fn bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
+impl<const L: usize> KeyDecodeBehaviorT for (FixedSizeKey<L>, Terminal) {
+    const BEHAVIOR: KeyDecodeBehavior = KeyDecodeBehavior::UseRest;
 }
 
-impl Key for str {
-    fn bytes(&self) -> &[u8] {
-        self.as_bytes()
-    }
+impl<const L: usize> KeyDecodeBehaviorT for (FixedSizeKey<L>, NonTerminal) {
+    const BEHAVIOR: KeyDecodeBehavior = KeyDecodeBehavior::UseN(L);
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
-#[error("invalid UTF8")]
-pub struct InvalidUtf8;
+impl KeyDecodeBehaviorT for (DynamicKey, Terminal) {
+    const BEHAVIOR: KeyDecodeBehavior = KeyDecodeBehavior::UseRest;
+}
 
-impl OwnedKey for String {
-    type Error = InvalidUtf8;
+impl KeyDecodeBehaviorT for (DynamicKey, NonTerminal) {
+    const BEHAVIOR: KeyDecodeBehavior = KeyDecodeBehavior::FollowLenPrefix;
+}
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        std::str::from_utf8(bytes)
-            .map(String::from)
-            .map_err(|_| InvalidUtf8)
+enum KeyDecodeBehavior {
+    FollowLenPrefix,
+    UseRest,
+    UseN(usize),
+}
+
+impl<K, V, Q> BoundFor<Map<K, V>> for &Q
+where
+    K: Borrow<Q> + OwnedKey,
+    V: Storable,
+    Q: Key + ?Sized,
+    (K::Kind, V::Kind): KeyDecodeBehaviorT,
+{
+    fn into_bytes(self) -> Vec<u8> {
+        let behavior = <(K::Kind, V::Kind)>::BEHAVIOR;
+
+        match behavior {
+            KeyDecodeBehavior::FollowLenPrefix => len_prefix(self.encode()),
+            _ => self.encode(),
+        }
     }
 }
 
@@ -323,13 +390,81 @@ mod tests {
 
         assert_eq!(map.access(&storage).entry("foo").get().unwrap(), Some(1337));
         assert_eq!(
-            storage.get(&[0, 3, 102, 111, 111]),
+            storage.get(&[0, 102, 111, 111]),
             Some(1337u64.to_le_bytes().to_vec())
         );
         map.access(&mut storage).entry_mut("foo").remove();
 
         assert_eq!(map.access(&storage).entry("foo").get().unwrap(), None);
         assert_eq!(map.access(&storage).entry("bar").get().unwrap(), None);
+    }
+
+    #[test]
+    fn bounded_iter_dyn_map_of_item() {
+        let mut storage = TestStorage::new();
+
+        let map = Map::<String, Item<u64, TestEncoding>>::new(0);
+        let mut access = map.access(&mut storage);
+
+        access.entry_mut("foo").set(&1337).unwrap();
+        access.entry_mut("bar").set(&42).unwrap();
+        access.entry_mut("baz").set(&69).unwrap();
+
+        let items = access
+            .bounded_pairs(Some("bar"), Some("bazz"))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            items,
+            vec![(("bar".to_string(), ()), 42), (("baz".to_string(), ()), 69)]
+        );
+    }
+
+    #[test]
+    fn iter_static_map_of_item() {
+        let mut storage = TestStorage::new();
+
+        let map = Map::<String, Item<u64, TestEncoding>>::new(0);
+        let mut access = map.access(&mut storage);
+
+        access.entry_mut("foo").set(&1337).unwrap();
+        access.entry_mut("bar").set(&42).unwrap();
+        access.entry_mut("baz").set(&69).unwrap();
+
+        let items = access.pairs().collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(
+            items,
+            vec![
+                (("bar".to_string(), ()), 42),
+                (("baz".to_string(), ()), 69),
+                (("foo".to_string(), ()), 1337)
+            ]
+        );
+    }
+
+    #[test]
+    fn bounded_iter_static_map_of_map() {
+        let mut storage = TestStorage::new();
+
+        let map = Map::<u32, Map<String, Item<u64, TestEncoding>>>::new(0);
+        let mut access = map.access(&mut storage);
+
+        access.entry_mut(&2).entry_mut("bar").set(&1337).unwrap();
+        access.entry_mut(&3).entry_mut("baz").set(&42).unwrap();
+        access.entry_mut(&4).entry_mut("quux").set(&69).unwrap();
+
+        let items = access
+            .bounded_pairs(Some(&2), Some(&4))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(
+            items,
+            vec![
+                ((2, ("bar".to_string(), ())), 1337),
+                ((3, ("baz".to_string(), ())), 42)
+            ]
+        );
     }
 
     #[test]

--- a/packages/storey/src/containers/mod.rs
+++ b/packages/storey/src/containers/mod.rs
@@ -15,6 +15,8 @@ use crate::storage::IterableStorage;
 
 /// The fundamental trait every collection/container should implement.
 pub trait Storable {
+    type Kind: StorableKind;
+
     /// The accessor type for this collection/container. An accessor is a type that provides
     /// methods for reading and writing to the collection/container and encapsulates the
     /// specific [`Storage`] type used (the `S` type parameter here).
@@ -245,3 +247,11 @@ where
         self.inner.next().map(|v| S::decode_value(&v))
     }
 }
+
+pub trait StorableKind {}
+
+pub struct Terminal;
+pub struct NonTerminal;
+
+impl StorableKind for Terminal {}
+impl StorableKind for NonTerminal {}

--- a/packages/storey/src/containers/mod.rs
+++ b/packages/storey/src/containers/mod.rs
@@ -68,7 +68,7 @@ pub enum KVDecodeError<K, V> {
     Value(V),
 }
 
-/// A trait for collection accessors (see [`Storable::AccessorT`]) that provide iteration over
+/// A trait for collection accessors (see [`Storable::Accessor`]) that provide iteration over
 /// their contents.
 pub trait IterableAccessor: Sized {
     /// The [`Storable`] type this accessor is associated with.
@@ -248,9 +248,24 @@ where
     }
 }
 
+/// The kind of a storable.
+///
+/// This is used to differentiate between terminal and non-terminal storables.
+/// See also: [`Terminal`] and [`NonTerminal`].
+///
+/// This trait is [sealed](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed)
+/// and cannot be implemented outside of this crate.
 pub trait StorableKind {}
 
+/// A terminal [`Storable`] kind. A terminal storable doesn't manage any subkeys,
+/// and is the end of the line in a composable collection.
+///
+/// An example of a terminal storable is [`Item`], but not [`Column`] or [`Map`].
 pub struct Terminal;
+
+/// A non-terminal [`Storable`] kind. A non-terminal storable manages subkeys.
+///
+/// Some examples of non-terminal storables are [`Column`] and [`Map`].
 pub struct NonTerminal;
 
 impl StorableKind for Terminal {}

--- a/packages/storey/src/containers/mod.rs
+++ b/packages/storey/src/containers/mod.rs
@@ -255,7 +255,7 @@ where
 ///
 /// This trait is [sealed](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed)
 /// and cannot be implemented outside of this crate.
-pub trait StorableKind {}
+pub trait StorableKind: sealed::StorableKindSeal {}
 
 /// A terminal [`Storable`] kind. A terminal storable doesn't manage any subkeys,
 /// and is the end of the line in a composable collection.
@@ -270,3 +270,10 @@ pub struct NonTerminal;
 
 impl StorableKind for Terminal {}
 impl StorableKind for NonTerminal {}
+
+mod sealed {
+    pub trait StorableKindSeal {}
+
+    impl StorableKindSeal for super::Terminal {}
+    impl StorableKindSeal for super::NonTerminal {}
+}

--- a/packages/storey/src/containers/mod.rs
+++ b/packages/storey/src/containers/mod.rs
@@ -3,7 +3,7 @@
 
 mod column;
 mod item;
-mod map;
+pub mod map;
 
 use std::marker::PhantomData;
 

--- a/packages/storey/tests/composition.rs
+++ b/packages/storey/tests/composition.rs
@@ -25,7 +25,7 @@ fn map_of_map() {
         Some(1337)
     );
     assert_eq!(
-        storage.get(&[0, 3, 102, 111, 111, 3, 98, 97, 114]),
+        storage.get(&[0, 3, 102, 111, 111, 98, 97, 114]),
         Some(1337u64.to_le_bytes().to_vec())
     );
     assert_eq!(

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -18,10 +18,9 @@ commit_parsers = [
     { message = "^changed", group = "<!-- 1 -->Changed" },
     { message = "^deprecated", group = "<!-- 2 -->Deprecated" },
     { message = "^fix", group = "<!-- 3 -->Fixed" },
-    { message = "^security", group = "<!-- 4 -->Security" },
+    { message = "^sec", group = "<!-- 4 -->Security" },
     { message = "^docs", group = "<!-- 5 -->Documentation" },
     { message = "^test", group = "<!-- 6 -->Tests" },
-    { message = "^.*", group = "<!-- 7 -->Other" },
 ]
 
 [workspace]


### PR DESCRIPTION
Closes #48

This whole monstrosity:
- enables bounded iteration for maps, but **only** if there's no length-prefixing of the key going on
- only length-prefixes keys when the key is dynamically sized AND it's not the final "component" of the complete key (as stored in the backend)
- implements numerical keys for maps

TODO:
- [x] simplify, rearrange, rename things, make everything easier to understand for future maintainers
- [x] internal documentation
- [x] review what should be public
- [x] API reference
- [x] complete tests
- [x] check if `Key`/`OwnedKey` implementors can receive something like `&[u8; 4]` when they specify their key as having 4 bytes, and `&[u8]` when they specify the key as dynamically sized - less custom error handling needed that way
    not easy: issue created - https://github.com/CosmWasm/storey/issues/58
- [x] look for other std types to implement `OwnedKey`/`Key` for
- [x] can this kind of stuff help make key types we get from iteration a little less crazy?
    separate issue: https://github.com/CosmWasm/storey/issues/59