### PR TITLE
fix: Use same bound type for start and end of iteration

### DIFF
--- a/packages/storey/src/containers/column.rs
+++ b/packages/storey/src/containers/column.rs
@@ -558,6 +558,7 @@ mod tests {
         access.push(&2).unwrap();
         access.remove(2).unwrap();
 
+        // start and end set
         assert_eq!(
             access
                 .bounded_pairs(Some(1), Some(4))
@@ -565,7 +566,6 @@ mod tests {
                 .unwrap(),
             vec![(1, 42), (3, 1)]
         );
-
         assert_eq!(
             access
                 .bounded_keys(Some(1), Some(4))
@@ -573,13 +573,58 @@ mod tests {
                 .unwrap(),
             vec![1, 3]
         );
-
         assert_eq!(
             access
                 .bounded_values(Some(1), Some(4))
                 .collect::<Result<Vec<_>, _>>()
                 .unwrap(),
             vec![42, 1]
+        );
+
+        // end unset
+        assert_eq!(
+            access
+                .bounded_pairs(Some(1), None)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![(1, 42), (3, 1), (4, 2)]
+        );
+        assert_eq!(
+            access
+                .bounded_keys(Some(1), None)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![1, 3, 4]
+        );
+        assert_eq!(
+            access
+                .bounded_values(Some(1), None)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![42, 1, 2]
+        );
+
+        // start unset
+        assert_eq!(
+            access
+                .bounded_pairs(None, Some(4))
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![(0, 1337), (1, 42), (3, 1)]
+        );
+        assert_eq!(
+            access
+                .bounded_keys(None, Some(4))
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![0, 1, 3]
+        );
+        assert_eq!(
+            access
+                .bounded_values(None, Some(4))
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![1337, 42, 1]
         );
     }
 }

--- a/packages/storey/src/containers/mod.rs
+++ b/packages/storey/src/containers/mod.rs
@@ -125,14 +125,13 @@ pub trait IterableAccessor: Sized {
 /// in turn means the entries found between two string keys may not be the expected ones.
 pub trait BoundedIterableAccessor: IterableAccessor {
     /// Iterate over key-value pairs in this collection, respecting the given bounds.
-    fn bounded_pairs<S, E>(
+    fn bounded_pairs<B>(
         &self,
-        start: Option<S>,
-        end: Option<E>,
+        start: Option<B>,
+        end: Option<B>,
     ) -> StorableIter<'_, Self::Storable, Self::Storage>
     where
-        S: BoundFor<Self::Storable>,
-        E: BoundFor<Self::Storable>,
+        B: BoundFor<Self::Storable>,
     {
         let start = start.map(|b| b.into_bytes());
         let end = end.map(|b| b.into_bytes());
@@ -144,14 +143,13 @@ pub trait BoundedIterableAccessor: IterableAccessor {
     }
 
     /// Iterate over keys in this collection, respecting the given bounds.
-    fn bounded_keys<S, E>(
+    fn bounded_keys<B>(
         &self,
-        start: Option<S>,
-        end: Option<E>,
+        start: Option<B>,
+        end: Option<B>,
     ) -> StorableKeys<'_, Self::Storable, Self::Storage>
     where
-        S: BoundFor<Self::Storable>,
-        E: BoundFor<Self::Storable>,
+        B: BoundFor<Self::Storable>,
     {
         let start = start.map(|b| b.into_bytes());
         let end = end.map(|b| b.into_bytes());
@@ -163,14 +161,13 @@ pub trait BoundedIterableAccessor: IterableAccessor {
     }
 
     /// Iterate over values in this collection, respecting the given bounds.
-    fn bounded_values<S, E>(
+    fn bounded_values<B>(
         &self,
-        start: Option<S>,
-        end: Option<E>,
+        start: Option<B>,
+        end: Option<B>,
     ) -> StorableValues<'_, Self::Storable, Self::Storage>
     where
-        S: BoundFor<Self::Storable>,
-        E: BoundFor<Self::Storable>,
+        B: BoundFor<Self::Storable>,
     {
         let start = start.map(|b| b.into_bytes());
         let end = end.map(|b| b.into_bytes());


### PR DESCRIPTION
Before this change I ran into the problem of obscure error messages due to inability to infer the bound type for a `None` value. I hit it in a contract as follows:

<img width="1227" alt="Bildschirmfoto 2024-09-20 um 23 36 56" src="https://github.com/user-attachments/assets/e1149c6c-bc41-4980-a3c6-6b71dd0a0281">

I could reproduce the problem in the local test cases with `None` starts or ends. I don't think that we need to support different start and end bound types in the same call. Users can convert then in the unlikely event that they come in different types.  But let me know if this is an important feature which I did not understand.